### PR TITLE
Update config contract name

### DIFF
--- a/src/Extension/Dispatcher.php
+++ b/src/Extension/Dispatcher.php
@@ -1,6 +1,6 @@
 <?php namespace Orchestra\Extension;
 
-use Illuminate\Contracts\Config\Config;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
@@ -12,7 +12,7 @@ class Dispatcher implements DispatcherInterface
     /**
      * Config Repository instance.
      *
-     * @var \Illuminate\Contracts\Config\Config
+     * @var \Illuminate\Contracts\Config\Repository
      */
     protected $config;
 
@@ -54,7 +54,7 @@ class Dispatcher implements DispatcherInterface
     /**
      * Construct a new Application instance.
      *
-     * @param  \Illuminate\Contracts\Config\Config      $config
+     * @param  \Illuminate\Contracts\Config\Repository      $config
      * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @param  \Illuminate\Filesystem\Filesystem        $files
      * @param  Finder                                   $finder

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -33,7 +33,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
     public function testStartMethod()
     {
         $provider = $this->getProvider();
-        $config   = m::mock('\Illuminate\Contracts\Config\Config');
+        $config   = m::mock('\Illuminate\Contracts\Config\Repository');
         $event    = m::mock('\Illuminate\Contracts\Events\Dispatcher');
         $files    = m::mock('\Illuminate\Filesystem\Filesystem');
         $finder   = m::mock('\Orchestra\Extension\Finder');
@@ -107,7 +107,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function testFinishMethod()
     {
-        $config   = m::mock('\Illuminate\Contracts\Config\Config');
+        $config   = m::mock('\Illuminate\Contracts\Config\Repository');
         $event    = m::mock('\Illuminate\Contracts\Events\Dispatcher');
         $files    = m::mock('\Illuminate\Filesystem\Filesystem');
         $finder   = m::mock('\Orchestra\Extension\Finder');


### PR DESCRIPTION
Seems like laravel renamed `Illuminate\Contracts\Config\Config` to `Illuminate\Contracts\Config\Repository` 

https://github.com/laravel/framework/tree/master/src/Illuminate/Contracts/Config

This will throw an error for a clean installation of Orchestra/Platform

Signed-off-by: Ahmad Shah Hafizan Hamidin ahmadshahhafizan@gmail.com
